### PR TITLE
fix: Add missing updatedAt field to EmailRoomDto class

### DIFF
--- a/app/src/main/java/com/example/autocompose/data/database/EmailFirestoreDTO.kt
+++ b/app/src/main/java/com/example/autocompose/data/database/EmailFirestoreDTO.kt
@@ -14,4 +14,5 @@ data class EmailRoomDto(
     val subject: String = "",
     val emailBody: String = "",
     val frequency: Int = 1,
+     val updatedAt: FieldValue = FieldValue.serverTimestamp()
 )

--- a/app/src/main/java/com/example/autocompose/data/database/Entity.kt
+++ b/app/src/main/java/com/example/autocompose/data/database/Entity.kt
@@ -11,5 +11,5 @@ data class Entity(
     val subject : String,
     val emailBody: String,
     val frequency: Int = 1,
-//    val updatedAt: FieldValue = FieldValue.serverTimestamp()
+ val updatedAt: FieldValue = FieldValue.serverTimestamp()
 )


### PR DESCRIPTION
- Add updatedAt field to EmailRoomDto to match EmailFirestoreDto structure
- This ensures proper synchronization of email update timestamps between Room database and Firestore
- Fixes issue #14